### PR TITLE
app_name default of none crashes user agent

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -71,7 +71,7 @@ class AdyenClient(object):
                  store_payout_username=None, store_payout_password=None,
                  platform="test", merchant_account=None,
                  merchant_specific_url=None, skin_code=None,
-                 hmac=None, app_name=None,
+                 hmac=None, app_name="",
                  http_force=None, live_endpoint_prefix=None):
         self.username = username
         self.password = password


### PR DESCRIPTION
Fix for issue https://github.com/Adyen/adyen-python-api-library/issues/66

```
Traceback (most recent call last):
  ...
  File ".../venv/lib/python3.7/site-packages/Adyen/httpclient.py", line 41, in __init__
    self.user_agent = app_name + " " + user_agent_suffix + lib_version
  TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```


**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
While following the API Integration guide, the suggested instantiation of the Adyen class is:

```python
adyen = Adyen.Adyen()
adyen.client.xapikey = 'YOUR X-API-KEY'
```

Making and API call with this configuration will result in the following error.

```
Traceback (most recent call last):
  ...
  File ".../venv/lib/python3.7/site-packages/Adyen/httpclient.py", line 41, in __init__
    self.user_agent = app_name + " " + user_agent_suffix + lib_version
  TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
Because the default for app_name is None instead of an empty string, or another string type default value.

**Tested scenarios**
<!-- Description of tested scenarios -->
Make an API call with app_name set to None.


**Fixed issue**:  <!-- #-prefixed issue number -->
66