### PR TITLE
HTTPClient interface #65

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -222,11 +222,13 @@ class AdyenClient(object):
 
         # username at self object has highest priority. fallback to root module
         # and ensure that it is set.
+        xapikey = None
         if self.xapikey:
             xapikey = self.xapikey
         elif 'xapikey' in kwargs:
             xapikey = kwargs.pop("xapikey")
 
+        username = None
         if self.username:
             username = self.username
         elif 'username' in kwargs:
@@ -237,7 +239,8 @@ class AdyenClient(object):
                 username = self._store_payout_username(**kwargs)
             else:
                 username = self._review_payout_username(**kwargs)
-        if not username:
+
+        if not username and not xapikey:
             errorstring = """Please set your webservice username.
               You can do this by running
               'Adyen.username = 'Your username'"""
@@ -245,7 +248,9 @@ class AdyenClient(object):
             # password at self object has highest priority.
             # fallback to root module
             # and ensure that it is set.
-        if self.password:
+
+        password = None
+        if self.password and not xapikey:
             password = self.password
         elif 'password' in kwargs:
             password = kwargs.pop("password")
@@ -255,7 +260,8 @@ class AdyenClient(object):
                 password = self._store_payout_pass(**kwargs)
             else:
                 password = self._review_payout_pass(**kwargs)
-        if not password:
+
+        if not password and not xapikey:
             errorstring = """Please set your webservice password.
               You can do this by running
               'Adyen.password = 'Your password'"""

--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -265,7 +265,7 @@ class HTTPClient(object):
             url_request.add_header("Authorization",
                                    "Basic %s" % basic_authstring)
         elif xapikey:
-            headers["X-API-KEY] = xapikey
+            headers["X-API-KEY"] = xapikey
 
         # Adding the headers to the request.
         for key, value in headers.items():

--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -104,7 +104,7 @@ class HTTPClient(object):
         # Add User-Agent header to request so that the
         # request can be identified as coming from the Adyen Python library.
         headers['User-Agent'] = self.user_agent
-  
+
         if username and password:
             curl.setopt(curl.USERPWD, '%s:%s' % (username, password))
         elif xapikey:
@@ -127,7 +127,7 @@ class HTTPClient(object):
         # Set the request body.
         raw_request = json_lib.dumps(json) if json else urlencode(data)
         curl.setopt(curl.POSTFIELDS, raw_request)
-            
+
         curl.setopt(curl.TIMEOUT, timeout)
         curl.perform()
 

--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -203,7 +203,7 @@ class HTTPClient(object):
                      data=None,
                      username="",
                      password="",
-                     xapikey=""
+                     xapikey="",
                      headers={},
                      timeout=30):
 

--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -60,6 +60,7 @@ class HTTPClient(object):
                      data=None,
                      username="",
                      password="",
+                     xapikey="",
                      headers={},
                      timeout=30):
         """This function will POST to the url endpoint using pycurl. returning
@@ -77,6 +78,8 @@ class HTTPClient(object):
                 as part of password.
             password (str, optional): Password for basic auth. Must be included
                 as part of username.
+            xapikey (str, optional):    Adyen API key.  Will be used for auth
+                                        if username and password are absent.
             headers (dict, optional): Key/Value pairs of headers to include
             timeout (int, optional): Default 30. Timeout for the request.
 
@@ -101,6 +104,11 @@ class HTTPClient(object):
         # Add User-Agent header to request so that the
         # request can be identified as coming from the Adyen Python library.
         headers['User-Agent'] = self.user_agent
+  
+        if username and password:
+            curl.setopt(curl.USERPWD, '%s:%s' % (username, password))
+        elif xapikey:
+            headers["X-API-KEY"] = xapikey
 
         # Convert the header dict to formatted array as pycurl needs.
         if sys.version_info[0] >= 3:
@@ -119,10 +127,7 @@ class HTTPClient(object):
         # Set the request body.
         raw_request = json_lib.dumps(json) if json else urlencode(data)
         curl.setopt(curl.POSTFIELDS, raw_request)
-
-        if username and password:
-            curl.setopt(curl.USERPWD, '%s:%s' % (username, password))
-
+            
         curl.setopt(curl.TIMEOUT, timeout)
         curl.perform()
 
@@ -143,7 +148,7 @@ class HTTPClient(object):
                        username="",
                        password="",
                        xapikey="",
-                       headers=None,
+                       headers={},
                        timeout=30):
         """This function will POST to the url endpoint using requests.
         Returning an AdyenResult object on 200 HTTP response.
@@ -160,6 +165,8 @@ class HTTPClient(object):
                 as part of password.
             password (str, optional): Password for basic auth. Must be included
                 as part of username.
+            xapikey (str, optional):    Adyen API key.  Will be used for auth
+                                        if username and password are absent.
             headers (dict, optional): Key/Value pairs of headers to include
             timeout (int, optional): Default 30. Timeout for the request.
 
@@ -169,8 +176,6 @@ class HTTPClient(object):
             int:    HTTP status code, eg 200,404,401
             dict:   Key/Value pairs of the headers received.
         """
-        if headers is None:
-            headers = {}
 
         # Adding basic auth if username and password provided.
         auth = None
@@ -194,11 +199,12 @@ class HTTPClient(object):
         return request.text, message, request.status_code, request.headers
 
     def _urllib_post(self, url,
-                     json="",
-                     data="",
+                     json=None,
+                     data=None,
                      username="",
                      password="",
-                     headers=None,
+                     xapikey=""
+                     headers={},
                      timeout=30):
 
         """This function will POST to the url endpoint using urllib2. returning
@@ -216,6 +222,8 @@ class HTTPClient(object):
                                         uncluded as part of password.
             password (str, optional):   Password for basic auth. Must be
                                         included as part of username.
+            xapikey (str, optional):    Adyen API key.  Will be used for auth
+                                        if username and password are absent.
             headers (dict, optional):   Key/Value pairs of headers to include
             timeout (int, optional): Default 30. Timeout for the request.
 
@@ -225,8 +233,6 @@ class HTTPClient(object):
             int:    HTTP status code, eg 200,404,401
             dict:   Key/Value pairs of the headers received.
         """
-        if headers is None:
-            headers = {}
 
         # Store regular dict to return later:
         raw_store = json
@@ -258,6 +264,8 @@ class HTTPClient(object):
                     replace('\n', '')
             url_request.add_header("Authorization",
                                    "Basic %s" % basic_authstring)
+        elif xapikey:
+            headers["X-API-KEY] = xapikey
 
         # Adding the headers to the request.
         for key, value in headers.items():
@@ -302,6 +310,8 @@ class HTTPClient(object):
                                         uncluded as part of password.
             password (str, optional):   Password for basic auth. Must be
                                         included as part of username.
+            xapikey (str, optional):    Adyen API key.  Will be used for auth
+                                        if username and password are absent.
             headers (dict, optional):   Key/Value pairs of headers to include
         Returns:
             str:    Raw request placed

--- a/test/BaseTest.py
+++ b/test/BaseTest.py
@@ -1,4 +1,8 @@
-import mock
+
+try:
+    import mock
+except Exception:
+    from unittest import mock
 import json
 from Adyen import httpclient
 

--- a/test/PaymentTest.py
+++ b/test/PaymentTest.py
@@ -5,6 +5,16 @@ from BaseTest import BaseTest
 
 class TestPayments(unittest.TestCase):
 
+    adyen = Adyen.Adyen()
+
+    client = adyen.client
+    test = BaseTest(adyen)
+    client.username = "YourWSUser"
+    client.password = "YourWSPassword"
+    client.platform = "test"
+    client.app_name = "appname"
+    client.xapikey = ""
+
     def test_authorise_success_mocked(self):
         request = {}
         request['merchantAccount'] = "YourMerchantAccount"
@@ -189,40 +199,222 @@ class TestPayments(unittest.TestCase):
                                 self.adyen.payment.authorise, request)
 
 
-class BasicAuth(TestPayments):
+class TestPaymentsWithXapiKey(unittest.TestCase):
+
     adyen = Adyen.Adyen()
 
     client = adyen.client
     test = BaseTest(adyen)
+    client.platform = "test"
+    client.app_name = "appname"
     client.username = "YourWSUser"
     client.password = "YourWSPassword"
-    client.platform = "test"
-    client.app_name = "appname"
+    client.xapikey = ""
+
+    def test_authorise_success_mocked(self):
+        request = {}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['amount'] = {"value": "100000", "currency": "EUR"}
+        request['reference'] = "123456"
+        request['card'] = {
+            "number": "5136333333333335",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "cvc": "737",
+            "holderName": "John Doe"
+        }
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-success'
+                                                              '.json')
+        result = self.adyen.payment.authorise(request)
+        self.assertEqual("Authorised", result.message['resultCode'])
+        self.assertEqual("8/2018",
+                         result.message['additionalData']['expiryDate'])
+        self.assertEqual("411111",
+                         result.message['additionalData']['cardBin'])
+        self.assertEqual("1111",
+                         result.message['additionalData']['cardSummary'])
+        self.assertEqual("Holder",
+                         result.message['additionalData']['cardHolderName'])
+        self.assertEqual("true",
+                         result.message['additionalData']['threeDOffered'])
+        self.assertEqual("false",
+                         result.message['additionalData']
+                         ['threeDAuthenticated'])
+        self.assertEqual("69746", result.message['authCode'])
+        self.assertEqual(11, len(result.message['fraudResult']['results']))
+        fraud_checks = result.message['fraudResult']['results']
+        fraud_check_result = fraud_checks[0]['FraudCheckResult']
+        self.assertEqual("CardChunkUsage", fraud_check_result['name'])
+        self.assertEqual(8, fraud_check_result['accountScore'])
+        self.assertEqual(2, fraud_check_result['checkId'])
+
+    def test_authorise_error010_mocked(self):
+        request = {}
+        request['merchantAccount'] = "testaccount"
+        request['amount'] = {"value": "100000", "currency": "EUR"}
+        request['reference'] = "123456"
+        request['card'] = {
+            "number": "5136333333333335",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "cvc": "737",
+            "holderName": "John Doe"
+        }
+        self.adyen.client = self.test.create_client_from_file(403, request,
+                                                              'test/mocks/'
+                                                              'authorise-error'
+                                                              '-010'
+                                                              '.json')
+        self.assertRaises(Adyen.AdyenAPIInvalidPermission,
+                          self.adyen.payment.authorise, request)
+
+    def test_authorise_error_cvc_declined_mocked(self):
+        request = {}
+        request['amount'] = {"value": "100000", "currency": "EUR"}
+        request['reference'] = "123456"
+        request['card'] = {
+            "number": "5136333333333335",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "cvc": "787",
+            "holderName": "John Doe"
+        }
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-error-'
+                                                              'cvc-declined'
+                                                              '.json')
+        result = self.adyen.payment.authorise(request)
+        self.assertEqual("Refused", result.message['resultCode'])
+
+    def test_authorise_success_3d_mocked(self):
+        request = {}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['amount'] = {"value": "100000", "currency": "EUR"}
+        request['reference'] = "123456"
+        request['card'] = {
+            "number": "5136333333333335",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "cvc": "787",
+            "holderName": "John Doe"
+        }
+        request['browserInfo'] = {
+            "userAgent": "YourUserAgent",
+            "acceptHeader": "YourAcceptHeader"
+        }
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-success'
+                                                              '-3d.json')
+        result = self.adyen.payment.authorise(request)
+        self.assertEqual("RedirectShopper", result.message['resultCode'])
+        self.assertIsNotNone(result.message['md'])
+        self.assertIsNotNone(result.message['issuerUrl'])
+        self.assertIsNotNone(result.message['paRequest'])
+
+    def test_authorise_3d_success_mocked(self):
+        request = {}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['md'] = "testMD"
+        request['paResponse'] = "paresponsetest"
+        request['browserInfo'] = {
+            "userAgent": "YourUserAgent",
+            "acceptHeader": "YourAcceptHeader"
+        }
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise3d-'
+                                                              'success.json')
+        result = self.adyen.payment.authorise3d(request)
+        self.assertEqual("Authorised", result.message['resultCode'])
+        self.assertIsNotNone(result.message['pspReference'])
+
+    def test_authorise_cse_success_mocked(self):
+        request = {}
+        request['amount'] = {"value": "1234", "currency": "EUR"}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['reference'] = "YourReference"
+        request['additionalData'] = {
+            "card.encrypted.json": "YourCSEToken"
+        }
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-success'
+                                                              '-cse.json')
+        result = self.adyen.payment.authorise(request)
+        self.assertEqual("Authorised", result.message['resultCode'])
+
+    def test_authorise_cse_error_expired_mocked(self):
+        request = {}
+        request['amount'] = {"value": "1234", "currency": "EUR"}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['reference'] = "YourReference"
+        request['additionalData'] = {
+            "card.encrypted.json": "YourCSEToken"
+        }
+
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-error-'
+                                                              'expired.json')
+        result = self.adyen.payment.authorise(request)
+        self.assertEqual("Refused", result.message['resultCode'])
+        self.assertEqual("DECLINED Expiry Incorrect",
+                         result.message['additionalData']['refusalReasonRaw'])
+
+    def test_error_401_mocked(self):
+        request = {}
+        request['merchantAccount'] = "YourMerchantAccount"
+        request['amount'] = {"value": "100000", "currency": "EUR"}
+        request['reference'] = "123456"
+        request['card'] = {
+            "number": "5136333333333335",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "cvc": "787",
+            "holderName": "John Doe"
+        }
+        self.adyen.client = self.test.create_client_from_file(401, request,
+                                                              'test/mocks/'
+                                                              'authorise'
+                                                              '-error-'
+                                                              '010.json')
+        self.assertRaisesRegexp(Adyen.AdyenAPIAuthenticationError,
+                                "Unable to authenticate with Adyen's Servers."
+                                " Please verify the credentials set with the"
+                                " Adyen base class. Please reach out to your"
+                                " Adyen Admin if the problem persists",
+                                self.adyen.payment.authorise, request)
 
 
-class XApiKey(TestPayments):
-    adyen = Adyen.Adyen()
+TestPayments.client.http_force = "requests"
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestPayments.client.http_force = "pycurl"
+TestPayments.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestPayments.client.http_force = "other"
+TestPayments.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
+unittest.TextTestRunner(verbosity=2).run(suite)
 
-    client = adyen.client
-    test = BaseTest(adyen)
-    client.platform = "test"
-    client.app_name = "appname"
-    client.xapikey = "YourWSXApiKey"
-
-
-def test_with(auth):
-    auth.client.http_force = "requests"
-    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    auth.client.http_force = "pycurl"
-    auth.client.http_init = False
-    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    auth.client.http_force = "other"
-    auth.client.http_init = False
-    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-
-
-test_with(BasicAuth)
-test_with(XApiKey)
+TestPaymentsWithXapiKey.client.http_force = "requests"
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPaymentsWithXapiKey)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestPaymentsWithXapiKey.client.http_force = "pycurl"
+TestPaymentsWithXapiKey.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPaymentsWithXapiKey)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestPaymentsWithXapiKey.client.http_force = "other"
+TestPaymentsWithXapiKey.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestPaymentsWithXapiKey)
+unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/PaymentTest.py
+++ b/test/PaymentTest.py
@@ -4,14 +4,6 @@ from BaseTest import BaseTest
 
 
 class TestPayments(unittest.TestCase):
-    adyen = Adyen.Adyen()
-
-    client = adyen.client
-    test = BaseTest(adyen)
-    client.username = "YourWSUser"
-    client.password = "YourWSPassword"
-    client.platform = "test"
-    client.app_name = "appname"
 
     def test_authorise_success_mocked(self):
         request = {}
@@ -197,14 +189,40 @@ class TestPayments(unittest.TestCase):
                                 self.adyen.payment.authorise, request)
 
 
-TestPayments.client.http_force = "requests"
-suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
-unittest.TextTestRunner(verbosity=2).run(suite)
-TestPayments.client.http_force = "pycurl"
-TestPayments.client.http_init = False
-suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
-unittest.TextTestRunner(verbosity=2).run(suite)
-TestPayments.client.http_force = "other"
-TestPayments.client.http_init = False
-suite = unittest.TestLoader().loadTestsFromTestCase(TestPayments)
-unittest.TextTestRunner(verbosity=2).run(suite)
+class BasicAuth(TestPayments):
+    adyen = Adyen.Adyen()
+
+    client = adyen.client
+    test = BaseTest(adyen)
+    client.username = "YourWSUser"
+    client.password = "YourWSPassword"
+    client.platform = "test"
+    client.app_name = "appname"
+
+
+class XApiKey(TestPayments):
+    adyen = Adyen.Adyen()
+
+    client = adyen.client
+    test = BaseTest(adyen)
+    client.platform = "test"
+    client.app_name = "appname"
+    client.xapikey = "YourWSXApiKey"
+
+
+def test_with(auth):
+    auth.client.http_force = "requests"
+    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+    auth.client.http_force = "pycurl"
+    auth.client.http_init = False
+    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+    auth.client.http_force = "other"
+    auth.client.http_init = False
+    suite = unittest.TestLoader().loadTestsFromTestCase(auth)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+test_with(BasicAuth)
+test_with(XApiKey)


### PR DESCRIPTION
Python version: 3.7.2
Library version: 2.0.0

HTTPClient:
Interface between requests (line 140), pycurl (line 57), and urllib (line 196) should be the same. 'Requests' has xapikey as a parameter while pycurl, and urllib do not.

Some other minor changes to make the interface more homogenous.

Further development should look at how json and data are handled differently in each library.  Depending what library you have installed, a falsy data or json object will raise an error, while others will send the request with a falsy value.

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Added the option to provide the xapikey despite what library you have installed to make a homogenous interface.  If I have one of the libraries installed it should just work, the interface shouldn't change if I have installed pycurl or requests.

Some other minor changes to make the interface more homogenous.

Further development should look at how json and data are handled differently in each library.  Depending what library you have installed, a falsy data or json object will raise an error, while others will send the request with a falsy value.

**Tested scenarios**
<!-- Description of tested scenarios -->
Make a request using the Adyen http client with requests installed passing xapikey as a parameter.  Now do the same using one of the other libraries and it will be an error.

**Fixed issue**:  <!-- #-prefixed issue number -->
Made API interface homogenous between libraries.

Further development should make error handling homogenous between libraries.