### PR TITLE
Patch 2

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -213,6 +213,13 @@ class AdyenClient(object):
             AdyenResult: The AdyenResult is returned when a request was
                 succesful.
         """
+        if not isinstance(request_data, dict):
+            raise AdyenInvalidRequestError("'request_data' must be of type 'dict'")
+
+        for param in [service, action]:
+            if not isinstance(param, str):
+                raise AdyenInvalidRequestError("'{0}' must be of type 'str'".format(param))
+
         if not self.http_init:
             self.http_client = HTTPClient(self.app_name,
                                           self.USER_AGENT_SUFFIX,
@@ -400,6 +407,13 @@ class AdyenClient(object):
             service (str): This is the API service to be called.
             action (str): The specific action of the API service to be called
         """
+        if not isinstance(request_data, dict):
+            raise AdyenInvalidRequestError("`request_data` must be of type dict.")
+
+        for param in [service, action]:
+            if not isinstance(param, str):
+                raise AdyenInvalidRequestError("'{0}' must be of type 'str'".format(param))
+
         if not self.http_init:
             self.http_client = HTTPClient(self.app_name,
                                           self.USER_AGENT_SUFFIX,

--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -410,9 +410,8 @@ class AdyenClient(object):
         if not isinstance(request_data, dict):
             raise AdyenInvalidRequestError("`request_data` must be of type dict.")
 
-        for param in [service, action]:
-            if not isinstance(param, str):
-                raise AdyenInvalidRequestError("'{0}' must be of type 'str'".format(param))
+        if not isinstance(action, str):
+            raise AdyenInvalidRequestError("'{0}' must be of type 'str'".format(action))
 
         if not self.http_init:
             self.http_client = HTTPClient(self.app_name,


### PR DESCRIPTION
**Description**
Add validation of params to api calls.  This helps endusers trouble shoot issues faster.  For example, if a user sends a serialised json as `request_data` instead of as a python dict, an understandable error will be raised before any other action is taken.

**Tested scenarios**

``` python
    import json
    from settings import adyen_config
    from Adyen import Adyen

    payload = {"country": "us", "amount": {"value": 100, "currency": "USD"}}
    adyen_client = Adyen(**adyen_config)
    resp = adyen_client.checkout.payment_methods(json.dumps(payload))
    print(resp)


>>>    File "/usr/local/lib/python3.7/site-packages/Adyen/client.py", line 430, in call_checkout_api
>>>        if not request_data.get('merchantAccount'):
>>>    AttributeError: 'str' object has no attribute 'get'
```

with fix should raise

``` python
>>>    File "/usr/local/lib/python3.7/site-packages/Adyen/client.py", line 410, in call_checkout_api
>>>        if not isinstance(request_data, dict):
>>>    AdyenInvalidRequestError: 'request_data' must be of type 'dict'
```
**Fixed issue**:  No issue number yet.
