### PR TITLE
Mutable types used as defaults

### DIFF
--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -61,7 +61,7 @@ class HTTPClient(object):
                      username="",
                      password="",
                      xapikey="",
-                     headers={},
+                     headers=None,
                      timeout=30):
         """This function will POST to the url endpoint using pycurl. returning
         an AdyenResult object on 200 HTTP responce. Either json or data has to
@@ -89,6 +89,8 @@ class HTTPClient(object):
             int:    HTTP status code, eg 200,404,401
             dict:   Key/Value pairs of the headers received.
         """
+        if headers is None:
+            headers = {}
 
         response_headers = {}
 
@@ -148,7 +150,7 @@ class HTTPClient(object):
                        username="",
                        password="",
                        xapikey="",
-                       headers={},
+                       headers=None,
                        timeout=30):
         """This function will POST to the url endpoint using requests.
         Returning an AdyenResult object on 200 HTTP response.
@@ -176,7 +178,9 @@ class HTTPClient(object):
             int:    HTTP status code, eg 200,404,401
             dict:   Key/Value pairs of the headers received.
         """
-
+        if headers is None:
+            headers = {}
+        
         # Adding basic auth if username and password provided.
         auth = None
         if username and password:
@@ -204,7 +208,7 @@ class HTTPClient(object):
                      username="",
                      password="",
                      xapikey="",
-                     headers={},
+                     headers=None,
                      timeout=30):
 
         """This function will POST to the url endpoint using urllib2. returning
@@ -234,6 +238,9 @@ class HTTPClient(object):
             dict:   Key/Value pairs of the headers received.
         """
 
+        if headers is None:
+            headers = {}
+        
         # Store regular dict to return later:
         raw_store = json
 

--- a/Adyen/httpclient.py
+++ b/Adyen/httpclient.py
@@ -180,7 +180,7 @@ class HTTPClient(object):
         """
         if headers is None:
             headers = {}
-        
+
         # Adding basic auth if username and password provided.
         auth = None
         if username and password:
@@ -240,7 +240,7 @@ class HTTPClient(object):
 
         if headers is None:
             headers = {}
-        
+
         # Store regular dict to return later:
         raw_store = json
 


### PR DESCRIPTION
Mutable types used as default values can have unexpected behaviour, such as maintaining it's previous value from the last call.

**Description**
There are some functions in the HTTPClient that use mutable defaults.  This can lead to unexpected behaviour.

**Tested scenarios**
This is well known behaviour in python.

```python
>>> def mutable_default_test(default={}):
...     print(default)
...     default["key"] = "value"
...
>>> mutable_default_test()
{}
>>> mutable_default_test()
{'key': 'value'}
>>> mutable_default_test({"something": "some value"})
{'something': 'some value'}
>>> mutable_default_test()
{'key': 'value'}
```

**Fixed issue**:
#77
