### PR TITLE
Preserve provided ApplicationInfo

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -314,7 +314,7 @@ class AdyenClient(object):
 
         if xapikey:
             raw_response, raw_request, status_code, headers = \
-                self.httap_client.request(url, json=request_data,
+                self.http_client.request(url, json=request_data,
                                          xapikey=xapikey, headers=headers,
                                          **kwargs)
         else:

--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -288,13 +288,22 @@ class AdyenClient(object):
 
         if not message.get('merchantAccount'):
             message['merchantAccount'] = self.merchant_account
+
         # Add application info
-        request_data['applicationInfo'] = {
-            "adyenLibrary": {
-                "name": settings.LIB_NAME,
-                "version": settings.LIB_VERSION
+        if 'applicationInfo' in request_data:
+            request_data['applicationInfo'].update({
+                "adyenLibrary": {
+                    "name": settings.LIB_NAME,
+                    "version": settings.LIB_VERSION
+                }
+            })
+        else:
+            request_data['applicationInfo'] = {
+                "adyenLibrary": {
+                    "name": settings.LIB_NAME,
+                    "version": settings.LIB_VERSION
+                }
             }
-        }
         # Adyen requires this header to be set and uses the combination of
         # merchant account and merchant reference to determine uniqueness.
         headers = {}
@@ -305,7 +314,7 @@ class AdyenClient(object):
 
         if xapikey:
             raw_response, raw_request, status_code, headers = \
-                self.http_client.request(url, json=request_data,
+                self.httap_client.request(url, json=request_data,
                                          xapikey=xapikey, headers=headers,
                                          **kwargs)
         else:
@@ -443,12 +452,20 @@ class AdyenClient(object):
         if not request_data.get('merchantAccount'):
             request_data['merchantAccount'] = self.merchant_account
 
-        request_data['applicationInfo'] = {
-            "adyenLibrary": {
-                "name": settings.LIB_NAME,
-                "version": settings.LIB_VERSION
+        if 'applicationInfo' in request_data:
+            request_data['applicationInfo'].update({
+                "adyenLibrary": {
+                    "name": settings.LIB_NAME,
+                    "version": settings.LIB_VERSION
+                }
+            })
+        else:
+            request_data['applicationInfo'] = {
+                "adyenLibrary": {
+                    "name": settings.LIB_NAME,
+                    "version": settings.LIB_VERSION
+                }
             }
-        }
         # Adyen requires this header to be set and uses the combination of
         # merchant account and merchant reference to determine uniqueness.
         headers = {}


### PR DESCRIPTION
**Description**
Adyen's Integration Guide requests that applications provide `applicationInformation` such as `merchantApplication` and `externalPlatform`.

However, this library is overwriting any provided information.

This PR addresses this issue and preserves any existing `applicationInformation`, only extending it with the `adyenLibrary`.

**Tested scenarios**
```python
    def _init_api(self, env=None):
        self.adyen = Adyen.Adyen(
            app_name='pretix',
            xapikey=self.settings.test_api_key if self.event.testmode else self.settings.prod_api_key,
            # API-calls go only to -live in prod - not to -live-au or -live-us like in the frontend.
            platform=env if env else 'test' if self.event.testmode else 'live',
            live_endpoint_prefix=self.settings.prod_prefix
        )

    @property
    def api_kwargs(self):
        kwargs = {
            'merchantAccount': self.settings.test_merchant_account if self.event.testmode
            else self.settings.prod_merchant_account,
            'applicationInfo': {
                'merchantApplication': {
                    'name': 'pretix-adyen',
                    'version': PluginApp.PretixPluginMeta.version,
                },
                'externalPlatform': {
                    'name': 'pretix',
                    'version': __version__,
                    'integrator': settings.PRETIX_INSTANCE_NAME,
                }
            }
        }

        return kwargs

    def execute_refund(self, refund: OrderRefund):
        self._init_api()

        payment_info = refund.payment.info_data

        if not payment_info:
            raise PaymentException(_('No payment information found.'))

        rqdata = {
            'modificationAmount': {
                'value': self._get_amount(refund),
                'currency': self.event.currency,
            },
            'originalReference': payment_info['pspReference'],
            'merchantOrderReference': '{event}-{code}'.format(event=self.event.slug.upper(), code=refund.order.code),
            'reference': '{event}-{code}-R-{payment}'.format(event=self.event.slug.upper(), code=refund.order.code, payment=refund.local_id),
            'shopperStatement': self.statement_descriptor(refund),
            'captureDelayHours': 0,
            **self.api_kwargs
        }

        try:
            result = self.adyen.payment.refund(rqdata)
        except AdyenError as e:
            logger.exception('AdyenError: %s' % str(e))
            return
```

**Fixed issue**: 
No issue has been filed beforehand
