### PR TITLE
Fix HMAC signature calculation

### DIFF
--- a/Adyen/util.py
+++ b/Adyen/util.py
@@ -44,3 +44,53 @@ def is_valid_hmac(dict_object, hmac_key):
             merchant_sign = generate_hpp_sig(dict_object, hmac_key)
             merchant_sign_str = merchant_sign.decode("utf-8")
             return merchant_sign_str == expected_sign
+
+
+def generate_notification_sig(dict_object, hmac_key):
+    if 'issuerId' in dict_object:
+        if dict_object['issuerId'] == "":
+            del dict_object['issuerId']
+
+    if not isinstance(dict_object, dict):
+        raise ValueError("Must Provide dictionary object")
+
+    def escape_val(val):
+        if isinstance(val, int):
+            return val
+        return val.replace('\\', '\\\\').replace(':', '\\:')
+
+    hmac_key = binascii.a2b_hex(hmac_key)
+
+    request_dict = dict(dict_object)
+    request_dict['value'] = request_dict['amount']['value']
+    request_dict['currency'] = request_dict['amount']['currency']
+
+    element_orders = [
+        'pspReference',
+        'originalReference',
+        'merchantAccountCode',
+        'merchantReference',
+        'value',
+        'currency',
+        'eventCode',
+        'success',
+    ]
+
+    signing_string = ':'.join(
+        map(escape_val, map(str, (
+            request_dict.get(element, '') for element in element_orders))))
+
+    hm = hmac.new(hmac_key, signing_string.encode('utf-8'), hashlib.sha256)
+    return base64.b64encode(hm.digest())
+
+
+def is_valid_hmac_notification(dict_object, hmac_key):
+    if 'additionalData' in dict_object:
+        if dict_object['additionalData']['hmacSignature'] == "":
+            raise ValueError("Must Provide hmacSignature in additionalData")
+        else:
+            expected_sign = dict_object['additionalData']['hmacSignature']
+            del dict_object['additionalData']
+            merchant_sign = generate_notification_sig(dict_object, hmac_key)
+            merchant_sign_str = merchant_sign.decode("utf-8")
+            return merchant_sign_str == expected_sign

--- a/test/UtilTest.py
+++ b/test/UtilTest.py
@@ -1,15 +1,19 @@
 import unittest
 
 import Adyen
-from Adyen import generate_hpp_sig
-from Adyen.util import is_valid_hmac
+from Adyen.util import (
+    generate_hpp_sig,
+    is_valid_hmac,
+    generate_notification_sig,
+    is_valid_hmac_notification,
+)
 
 
 class UtilTest(unittest.TestCase):
     ady = Adyen.Adyen()
     client = ady.client
 
-    def test_notification_request_item_hmac(self):
+    def test_hpp_request_item_hmac(self):
         request = {
             "pspReference": "pspReference",
             "originalReference": "originalReference",
@@ -30,4 +34,34 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(hmac_calculation_str, expected_hmac)
         request['additionalData'] = {'hmacSignature': hmac_calculation_str}
         hmac_validate = is_valid_hmac(request, key)
+        self.assertTrue(hmac_validate)
+
+    def test_notification_request_item_hmac(self):
+        request = {
+            "pspReference": "7914073381342284",
+            "merchantReference": "TestPayment-1407325143704",
+            "merchantAccountCode": "TestMerchant",
+            "amount": {
+                "currency": "EUR",
+                "value": 1130
+            },
+            "eventCode": "AUTHORISATION",
+            "success": "true",
+            "eventDate": "2019-05-06T17:15:34.121+02:00",
+            "operations": [
+               "CANCEL",
+               "CAPTURE",
+               "REFUND"
+            ],
+            "paymentMethod": "visa",
+        }
+        key = "44782DEF547AAA06C910C43932B1EB0C" \
+              "71FC68D9D0C057550C48EC2ACF6BA056"
+        hmac_calculation = generate_notification_sig(request, key)
+        hmac_calculation_str = hmac_calculation.decode("utf-8")
+        expected_hmac = "coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0="
+        self.assertTrue(hmac_calculation_str != "")
+        self.assertEqual(hmac_calculation_str, expected_hmac)
+        request['additionalData'] = {'hmacSignature': hmac_calculation_str}
+        hmac_validate = is_valid_hmac_notification(request, key)
         self.assertTrue(hmac_validate)


### PR DESCRIPTION
**Description**
Following issue https://github.com/Adyen/adyen-python-api-library/issues/96, we reviewed HMAC signature calculation, following [Adyen docs](https://docs.adyen.com/development-resources/notifications/verify-hmac-signatures).

**Tested scenarios**
Unit test for updated method has been updated following linked docs, with given example. There are other tests that should be updated too.

**Fixed issue**:  https://github.com/Adyen/adyen-python-api-library/issues/96

Fixes #96 