### PR TITLE
BinLookup: Add getCostEstimate.

### DIFF
--- a/Adyen/__init__.py
+++ b/Adyen/__init__.py
@@ -15,11 +15,13 @@ from .exceptions import (
 from .client import AdyenClient
 from .services import (
     AdyenBase,
+    AdyenBinLookup,
     AdyenRecurring,
     AdyenPayment,
     AdyenThirdPartyPayout,
     AdyenHPP,
-    AdyenCheckoutApi)
+    AdyenCheckoutApi
+)
 
 from .httpclient import HTTPClient
 
@@ -28,6 +30,7 @@ class Adyen(AdyenBase):
     def __init__(self, **kwargs):
         self.client = AdyenClient(**kwargs)
         self.payment = AdyenPayment(client=self.client)
+        self.binlookup = AdyenBinLookup(client=self.client)
         self.payout = AdyenThirdPartyPayout(client=self.client)
         self.hpp = AdyenHPP(client=self.client)
         self.recurring = AdyenRecurring(client=self.client)
@@ -40,3 +43,4 @@ hpp = _base_adyen_obj.hpp
 payment = _base_adyen_obj.payment
 payout = _base_adyen_obj.payout
 checkout = _base_adyen_obj.checkout
+binlookup = _base_adyen_obj.binlookup

--- a/Adyen/services.py
+++ b/Adyen/services.py
@@ -315,3 +315,26 @@ class AdyenCheckoutApi(AdyenServiceBase):
     def origin_keys(self, request="", **kwargs):
         action = "originKeys"
         return self.client.call_checkout_api(request, action, **kwargs)
+
+
+class AdyenBinLookup(AdyenServiceBase):
+    """This represents the Adyen API Bin Lookup service.
+
+    API call currently implemented: getCostEstimate.
+    Please refer to the Bin Lookup Manual for specifics around the API.
+    https://docs.adyen.com/api-explorer/#/BinLookup/v50/overview
+
+    Args:
+        client (AdyenAPIClient, optional): An API client for the service to
+            use. If not provided, a new API client will be created.
+    """
+
+    def __init__(self, client=None):
+        super(AdyenBinLookup, self).__init__(client=client)
+        self.service = "BinLookup"
+
+    def get_cost_estimate(self, request="", **kwargs):
+
+        action = "getCostEstimate"
+
+        return self.client.call_api(request, self.service, action, **kwargs)

--- a/test/mocks/BinLookupTest.py
+++ b/test/mocks/BinLookupTest.py
@@ -1,0 +1,81 @@
+import Adyen
+import unittest
+from BaseTest import BaseTest
+
+
+class TestBinLookup(unittest.TestCase):
+    ady = Adyen.Adyen()
+
+    client = ady.client
+    test = BaseTest(ady)
+    client.username = "YourWSUser"
+    client.password = "YourWSPassword"
+    client.platform = "test"
+    client.app_name = "appname"
+
+    def test_get_cost_estimate_success(self):
+        request = {
+            'merchantAccount': 'YourMerchantAccount',
+            'amount': '1000'
+        }
+
+        expected = {
+            'cardBin': {
+                'bin': '458012',
+                'commercial': False,
+                'fundingSource': 'CHARGE',
+                'fundsAvailability': 'N',
+                'issuingBank': 'Bank Of America',
+                'issuingCountry': 'US', 'issuingCurrency': 'USD',
+                'paymentMethod': 'Y',
+                'summary': '6789'
+            },
+            'costEstimateAmount': {
+                'currency': 'USD', 'value': 1234
+            },
+            'resultCode': 'Success',
+            'surchargeType': 'PASSTHROUGH'
+        }
+
+        self.ady.client = self.test.create_client_from_file(
+            status=200,
+            request=request,
+            filename='test/mocks/binlookup/getcostestimate-success.json'
+        )
+
+        result = self.ady.binlookup.get_cost_estimate(request)
+        self.assertEqual(expected, result.message)
+
+    def test_get_cost_estimate_error_mocked(self):
+        request = {
+            'merchantAccount': 'YourMerchantAccount',
+            'amount': '1000'
+        }
+
+        self.ady.client = self.test.create_client_from_file(
+            status=200,
+            request=request,
+            filename=(
+                "test/mocks/binlookup/"
+                "getcostestimate-error-invalid-data-422.json"
+            )
+        )
+
+        result = self.ady.binlookup.get_cost_estimate(request)
+        self.assertEqual(422, result.message['status'])
+        self.assertEqual("101", result.message['errorCode'])
+        self.assertEqual("Invalid card number", result.message['message'])
+        self.assertEqual("validation", result.message['errorType'])
+
+
+TestBinLookup.client.http_force = "requests"
+suite = unittest.TestLoader().loadTestsFromTestCase(TestBinLookup)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestBinLookup.client.http_force = "pycurl"
+TestBinLookup.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestBinLookup)
+unittest.TextTestRunner(verbosity=2).run(suite)
+TestBinLookup.client.http_force = "other"
+TestBinLookup.client.http_init = False
+suite = unittest.TestLoader().loadTestsFromTestCase(TestBinLookup)
+unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/mocks/binlookup/getcostestimate-error-invalid-data-422.json
+++ b/test/mocks/binlookup/getcostestimate-error-invalid-data-422.json
@@ -1,0 +1,6 @@
+{
+  "status": 422,
+  "errorCode": "101",
+  "message": "Invalid card number",
+  "errorType": "validation"
+}

--- a/test/mocks/binlookup/getcostestimate-success.json
+++ b/test/mocks/binlookup/getcostestimate-success.json
@@ -1,0 +1,19 @@
+{
+  "cardBin": {
+    "bin": "458012",
+    "commercial": false,
+    "fundingSource": "CHARGE",
+    "fundsAvailability": "N",
+    "issuingBank": "Bank Of America",
+    "issuingCountry": "US",
+    "issuingCurrency": "USD",
+    "paymentMethod": "Y",
+    "summary": "6789"
+  },
+  "costEstimateAmount": {
+    "currency": "USD",
+    "value": 1234
+  },
+  "resultCode": "Success",
+  "surchargeType": "PASSTHROUGH"
+}


### PR DESCRIPTION
**Description**
Add support for getCostEstimate which is one of the two APIs exposed by
the BinLookup service. This will allow broader support for the already-existing BinLookup service by the Adyen Python API client.

**Tested scenarios**
- Successful call to getCostEstimate.
- Failed call to getCostEstimate that's resulted from a bad card number.
