### PR TITLE
BIN Lookup API: Specify version.

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -108,6 +108,8 @@ class AdyenClient(object):
             api_version = settings.API_RECURRING_VERSION
         elif service == "Payout":
             api_version = settings.API_PAYOUT_VERSION
+        elif service == "BinLookup":
+            api_version = settings.API_BIN_LOOKUP_VERSION
         else:
             api_version = settings.API_PAYMENT_VERSION
         return '/'.join([base_uri, service, api_version, action])

--- a/Adyen/settings.py
+++ b/Adyen/settings.py
@@ -4,6 +4,7 @@ BASE_HPP_URL = "https://{}.adyen.com/hpp"
 ENDPOINT_CHECKOUT_TEST = "https://checkout-test.adyen.com"
 ENDPOINT_CHECKOUT_LIVE_SUFFIX = "https://{}-checkout-live" \
                                 ".adyenpayments.com/checkout"
+API_BIN_LOOKUP_VERSION = "v50"
 API_CHECKOUT_VERSION = "v49"
 API_CHECKOUT_UTILITY_VERSION = "v1"
 API_RECURRING_VERSION = "v25"


### PR DESCRIPTION
**Description**

Following a recent PR to add support for the BINLookup API, it seems
I've forgot to specify the API version. this caused call failures as the
BINLookup API only supports v40/v50 versions while the default version
is v49.

**Fixed issue**:  A followup fix for #106. 
