### PR TITLE
[PW-3248] Remove colon replacement in `is_valid_hmac_notification()`

### DIFF
--- a/Adyen/util.py
+++ b/Adyen/util.py
@@ -57,7 +57,7 @@ def generate_notification_sig(dict_object, hmac_key):
     def escape_val(val):
         if isinstance(val, int):
             return val
-        return val.replace('\\', '\\\\').replace(':', '\\:')
+        return val.replace('\\', '\\\\')
 
     hmac_key = binascii.a2b_hex(hmac_key)
 


### PR DESCRIPTION
**Description**
We don't need to replace the colons when creating the payload for the HMAC signature - if we do, it generates the wrong signature and verification fails

**Fixed issue**:  #117 
