### PR TITLE
Headers: Remove unneeded 'applicationInfo'.

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -328,13 +328,7 @@ class AdyenClient(object):
                     "version": settings.LIB_VERSION
                 }
             })
-        else:
-            request_data['applicationInfo'] = {
-                "adyenLibrary": {
-                    "name": settings.LIB_NAME,
-                    "version": settings.LIB_VERSION
-                }
-            }
+
         # Adyen requires this header to be set and uses the combination of
         # merchant account and merchant reference to determine uniqueness.
         headers = {}
@@ -490,13 +484,7 @@ class AdyenClient(object):
                     "version": settings.LIB_VERSION
                 }
             })
-        else:
-            request_data['applicationInfo'] = {
-                "adyenLibrary": {
-                    "name": settings.LIB_NAME,
-                    "version": settings.LIB_VERSION
-                }
-            }
+
         # Adyen requires this header to be set and uses the combination of
         # merchant account and merchant reference to determine uniqueness.
         headers = {}


### PR DESCRIPTION
**Description**

Following Adyen's services upgrade to V6X, the API rejects calls with redundant fields in them.
According to customer support ticket #1662487, it seems that the following fields are redundant when not used in conjunction with other 'applicationInfo' data:

```jsonc
{
   "paymentData" : "******...[truncated]",
   "details" : {
      "resultCode" : "0"
   },
   "merchantAccount" : null, //Not required
   "applicationInfo" : { //Not required
      "adyenLibrary" : { //Not required
         "name" : "adyen-python-api-library", //Not required
         "version" : "3.1.0" //Not required
      }
   }
}
```

