### PR TITLE
[PW-3549] filter services which uses ApplicationInfo

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -483,20 +483,30 @@ class AdyenClient(object):
         if not request_data.get('merchantAccount'):
             request_data['merchantAccount'] = self.merchant_account
 
-        if 'applicationInfo' in request_data:
-            request_data['applicationInfo'].update({
-                "adyenLibrary": {
-                    "name": settings.LIB_NAME,
-                    "version": settings.LIB_VERSION
+        with_app_info = [
+            "authorise",
+            "authorise3d",
+            "authorise3ds2",
+            "payments",
+            "paymentSession",
+            "paymentLinks"
+        ]
+
+        if action in with_app_info:
+            if 'applicationInfo' in request_data:
+                request_data['applicationInfo'].update({
+                    "adyenLibrary": {
+                        "name": settings.LIB_NAME,
+                        "version": settings.LIB_VERSION
+                    }
+                })
+            else:
+                request_data['applicationInfo'] = {
+                    "adyenLibrary": {
+                        "name": settings.LIB_NAME,
+                        "version": settings.LIB_VERSION
+                    }
                 }
-            })
-        else:
-            request_data['applicationInfo'] = {
-                "adyenLibrary": {
-                    "name": settings.LIB_NAME,
-                    "version": settings.LIB_VERSION
-                }
-            }
         # Adyen requires this header to be set and uses the combination of
         # merchant account and merchant reference to determine uniqueness.
         headers = {}

--- a/test/CheckoutTest.py
+++ b/test/CheckoutTest.py
@@ -89,6 +89,32 @@ class TestCheckout(unittest.TestCase):
                                                               "-data-422"
                                                               ".json")
         result = self.adyen.checkout.payments(request)
+
+        self.adyen.client.http_client.request.assert_called_once_with(
+            'https://checkout-test.adyen.com/v64/payments',
+            headers={},
+            json={
+                'returnUrl': 'https://your-company.com/...',
+                u'applicationInfo': {
+                    u'adyenLibrary': {
+                        u'version': '3.1.0',
+                        u'name': 'adyen-python-api-library'
+                    }
+                },
+                'reference': '54431',
+                'merchantAccount': 'YourMerchantAccount',
+                'amount': {'currency': 'EUR', 'value': '100000'},
+                'paymentMethod': {
+                    'expiryYear': '2018',
+                    'holderName': 'John Smith',
+                    'number': '4111111111111111',
+                    'expiryMonth': '08',
+                    'type': 'scheme',
+                    'cvc': '737'
+                }
+            },
+            xapikey='YourXapikey'
+        )
         self.assertEqual(422, result.message['status'])
         self.assertEqual("130", result.message['errorCode'])
         self.assertEqual("Reference Missing", result.message['message'])
@@ -104,7 +130,19 @@ class TestCheckout(unittest.TestCase):
                                                               "checkout/"
                                                               "paymentsdetails"
                                                               "-success.json")
+
         result = self.adyen.checkout.payments_details(request)
+
+        self.adyen.client.http_client.request.assert_called_once_with(
+            u'https://checkout-test.adyen.com/v64/payments/details',
+            headers={},
+            json={
+                'paymentData': 'Hee57361f99....',
+                u'merchantAccount': None,
+                'details': {'MD': 'sdfsdfsdf...', 'PaRes': 'sdkfhskdjfsdf...'}
+            },
+            xapikey='YourXapikey'
+        )
         self.assertEqual("8515232733321252", result.message['pspReference'])
         self.assertEqual("Authorised", result.message['resultCode'])
         self.assertEqual("true",


### PR DESCRIPTION
**Description**
Add the `ApplicationInfo` just on the services which support it.

**Tested scenarios**
`/payments` -> should have `ApplicationInfo`
`/payments/details` -> should not have `ApplicationInfo`

**Fixed issue**:  Closes #125 
