### PR TITLE
Renaming master branch to main in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/Adyen/adyen-python-api-library.svg?branch=master)](https://travis-ci.org/Adyen/adyen-python-api-library)
-[![Coverage Status](https://coveralls.io/repos/github/Adyen/adyen-python-api-library/badge.svg?branch=master)](https://coveralls.io/github/Adyen/adyen-python-api-library?branch=master)
+[![Build Status](https://travis-ci.org/Adyen/adyen-python-api-library.svg?branch=main)](https://travis-ci.org/Adyen/adyen-python-api-library)
+[![Coverage Status](https://coveralls.io/repos/github/Adyen/adyen-python-api-library/badge.svg?branch=main)](https://coveralls.io/github/Adyen/adyen-python-api-library?branch=main)
 
 This is the officially supported Python library for using Adyen's APIs.
 ## Integration 
@@ -76,7 +76,7 @@ For other questions, [contact our Support Team](https://www.adyen.help/hc/en-us/
  
  
 ## Licence
-This repository is available under the [MIT license](https://github.com/Adyen/adyen-python-api-library/blob/master/LICENSE.md).
+This repository is available under the [MIT license](https://github.com/Adyen/adyen-python-api-library/blob/main/LICENSE.md).
  
  
 ## See also


### PR DESCRIPTION
## Summary
The `master` branch in this repo has been renamed to `main`.