### PR TITLE
Fix to check response body for psp ref first before we check header

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -646,7 +646,7 @@ class AdyenClient(object):
         else:
             try:
                 response = json_lib.loads(raw_response)
-                psp = headers.get('pspReference', response.get('pspReference'))
+                psp = self._get_psp(response, headers)
                 return AdyenResult(message=response, status_code=status_code,
                                    psp=psp, raw_request=raw_request,
                                    raw_response=raw_response)
@@ -794,3 +794,11 @@ class AdyenClient(object):
         match_obj = re.search(r'>Error:\s*(.*?)<br', html)
         if match_obj:
             return match_obj.group(1)
+
+    @staticmethod
+    def _get_psp(response, header):
+        psp_ref = response.get('pspReference')
+        if psp_ref == "":
+            return header.get('pspReference')
+        else:
+            return psp_ref


### PR DESCRIPTION
**Description**
#156 mentioned correctly that we should check the response body first for the pspReference instead of always just getting it from the headers. I added a static function to check this. It seems that only valid requests (200/201) can actually return a different psp ref, hence it just checks the response of those requests.