### PR TITLE
Fix incorrect detection of paymentsRefunds action

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -197,7 +197,7 @@ class AdyenClient(object):
             action = f"/payments/{path_param}/captures"
         if action == "paymentsReversals":
             action = f"payments/{path_param}/reversals"
-        if action == "payments/Refunds":
+        if action == "paymentsRefunds":
             action = f"payments/{path_param}/refunds"
         if action == "originKeys":
             api_version = self.api_checkout_utility_version


### PR DESCRIPTION
**Description**

Currently using "adyen.checkout.payments_refunds" fails with an unknown Method Call - action passed mismatches the action checking code.

