### PR TITLE
PSP Reference header fix

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -634,6 +634,6 @@ class AdyenClient(object):
     @staticmethod
     def _get_psp(response, headers):
         psp_ref = response.get('pspReference')
-        if not psp_ref:
+        if psp_ref is None:
             psp_ref = headers.get('pspReference')
         return psp_ref

--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -632,9 +632,8 @@ class AdyenClient(object):
                 headers=headers, error_code=response_obj.get("errorCode"))
 
     @staticmethod
-    def _get_psp(response, header):
+    def _get_psp(response, headers):
         psp_ref = response.get('pspReference')
-        if psp_ref == "":
-            return header.get('pspReference')
-        else:
-            return psp_ref
+        if not psp_ref:
+            psp_ref = headers.get('pspReference')
+        return psp_ref


### PR DESCRIPTION
**Description**
Currently the `_get_psp` method only uses the PSP Reference from the headers if the variable `psp_reference` is equal to empty string. The problem is that when calls are made which do **not** return any PSP Reference in the fields, this check fails, as variable `psp_reference` is set to None. I outlined more of this problem in the following issue: #177 

We specifically ran into this issue because when we create a new Payment Session, we don't obtain the original PSP reference (as it is not part of the response data) and therefore cannot initiate a refund as we require the original PSP reference. This solution will fix this by obtaining the PSP Reference from the header.
 
**Tested scenarios**
Existing unit tests pass

