### PR TITLE
Fix usage of xapikey in the kwargs of the methods

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -331,7 +331,7 @@ class AdyenClient(object):
             # fallback to root module
             # and ensure that it is set.
 
-        return xapikey, username, password
+        return xapikey, username, password, kwargs
 
     def _set_platform(self, **kwargs):
         # platform at self object has highest priority. fallback to root module
@@ -383,7 +383,7 @@ class AdyenClient(object):
             self._init_http_client()
 
         # Set credentials
-        xapikey, username, password = self._set_credentials(service, endpoint, **kwargs)
+        xapikey, username, password, kwargs= self._set_credentials(service, endpoint, **kwargs)
         # Set platform
         platform = self._set_platform(**kwargs)
         message = request_data

--- a/test/CheckoutTest.py
+++ b/test/CheckoutTest.py
@@ -597,3 +597,18 @@ class TestCheckout(unittest.TestCase):
             json=request
         )
         self.assertEqual("expired",result.message["status"])
+
+    def test_passing_xapikey_in_method(self):
+        request = {'merchantAccount': "YourMerchantAccount"}
+        self.adyen.client.xapikey = None
+        self.adyen.client = self.test.create_client_from_file(200, request,
+                                                              "test/mocks/"
+                                                              "checkout/"
+                                                              "paymentmethods"
+                                                              "-success.json")
+        result = self.adyen.checkout.payments_api.payment_methods(request, xapikey="YourXapikey")
+        self.assertEqual("AliPay", result.message['paymentMethods'][0]['name'])
+        self.assertEqual("Credit Card",
+                         result.message['paymentMethods'][2]['name'])
+        self.assertEqual("Credit Card via AsiaPay",
+                         result.message['paymentMethods'][3]['name'])

--- a/test/CheckoutTest.py
+++ b/test/CheckoutTest.py
@@ -598,17 +598,3 @@ class TestCheckout(unittest.TestCase):
         )
         self.assertEqual("expired",result.message["status"])
 
-    def test_passing_xapikey_in_method(self):
-        request = {'merchantAccount': "YourMerchantAccount"}
-        self.adyen.client.xapikey = None
-        self.adyen.client = self.test.create_client_from_file(200, request,
-                                                              "test/mocks/"
-                                                              "checkout/"
-                                                              "paymentmethods"
-                                                              "-success.json")
-        result = self.adyen.checkout.payments_api.payment_methods(request, xapikey="YourXapikey")
-        self.assertEqual("AliPay", result.message['paymentMethods'][0]['name'])
-        self.assertEqual("Credit Card",
-                         result.message['paymentMethods'][2]['name'])
-        self.assertEqual("Credit Card via AsiaPay",
-                         result.message['paymentMethods'][3]['name'])

--- a/test/UtilTest.py
+++ b/test/UtilTest.py
@@ -6,6 +6,10 @@ from Adyen.util import (
     is_valid_hmac_notification,
     get_query
 )
+try:
+    from BaseTest import BaseTest
+except ImportError:
+    from .BaseTest import BaseTest
 
 
 class UtilTest(unittest.TestCase):
@@ -68,3 +72,19 @@ class UtilTest(unittest.TestCase):
         }
         query_string = get_query(query_parameters)
         self.assertEqual(query_string,'?pageSize=7&pageNumber=3')
+
+    def test_passing_xapikey_in_method(self):
+        request = {'merchantAccount': "YourMerchantAccount"}
+        self.test = BaseTest(self.ady)
+        self.client.platform = "test"
+        self.ady.client = self.test.create_client_from_file(200, request,
+                                                              "test/mocks/"
+                                                              "checkout/"
+                                                              "paymentmethods"
+                                                              "-success.json")
+        result = self.ady.checkout.payments_api.payment_methods(request, xapikey="YourXapikey")
+        self.assertEqual("AliPay", result.message['paymentMethods'][0]['name'])
+        self.assertEqual("Credit Card",
+                         result.message['paymentMethods'][2]['name'])
+        self.assertEqual("Credit Card via AsiaPay",
+                         result.message['paymentMethods'][3]['name'])


### PR DESCRIPTION
**Description**
As mentioned here #233 when passing the xapikey in the method, there are two xapikeys that end up in the http client. By modifying the kwargs and *returning* it in the set_credenetials function only one is passed further. 

**Tested scenarios**
Added a unit test in checkout

**Fixed issue**:  
