### PR TITLE
Correct the copy for dict_object

### DIFF
--- a/Adyen/util.py
+++ b/Adyen/util.py
@@ -4,6 +4,8 @@ import base64
 import hmac
 import hashlib
 import binascii
+import copy
+
 
 
 def generate_notification_sig(dict_object, hmac_key):
@@ -35,7 +37,7 @@ def generate_notification_sig(dict_object, hmac_key):
 
 
 def is_valid_hmac_notification(dict_object, hmac_key):
-    dict_object = dict_object.copy()
+    dict_object = copy.deepcopy(dict_object) 
 
     if 'notificationItems' in dict_object:
         dict_object = dict_object['notificationItems'][0]['NotificationRequestItem']
@@ -45,7 +47,8 @@ def is_valid_hmac_notification(dict_object, hmac_key):
             raise ValueError("Must Provide hmacSignature in additionalData")
         else:
             expected_sign = dict_object['additionalData']['hmacSignature']
-            del dict_object['additionalData']
+            if 'additionalData' in dict_object:
+                del dict_object['additionalData']
             merchant_sign = generate_notification_sig(dict_object, hmac_key)
             merchant_sign_str = merchant_sign.decode("utf-8")
             return hmac.compare_digest(merchant_sign_str, expected_sign)

--- a/Adyen/util.py
+++ b/Adyen/util.py
@@ -47,8 +47,7 @@ def is_valid_hmac_notification(dict_object, hmac_key):
             raise ValueError("Must Provide hmacSignature in additionalData")
         else:
             expected_sign = dict_object['additionalData']['hmacSignature']
-            if 'additionalData' in dict_object:
-                del dict_object['additionalData']
+            del dict_object['additionalData']
             merchant_sign = generate_notification_sig(dict_object, hmac_key)
             merchant_sign_str = merchant_sign.decode("utf-8")
             return hmac.compare_digest(merchant_sign_str, expected_sign)

--- a/test/UtilTest.py
+++ b/test/UtilTest.py
@@ -108,3 +108,28 @@ class UtilTest(unittest.TestCase):
             json=request,
             xapikey="YourXapikey"
         )
+
+    def test_is_valid_hmac_notification_removes_additional_data(self):
+        notification = {
+                            "live":"false",
+                            "notificationItems":[
+                                {
+                                    "NotificationRequestItem":{
+                                        "additionalData":{
+                                        "hmacSignature":"11aa",
+                                        "fraudResultType":"GREEN",
+                                        "fraudManualReview": "false",
+                                        "totalFraudScore":"75"
+                                        },
+                                        "amount":{
+                                        "currency":"USD",
+                                        "value":10000
+                                        },
+                                        "success":"true"
+                                        
+                                    }
+                                }
+                            ]}
+        is_valid_hmac_notification(notification, "11aa")
+        self.assertIsNotNone(notification['notificationItems'][0]['NotificationRequestItem']['additionalData'])
+    


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
To avoid this the `additionalData ` remove for the original object create a deep copy (copying nested objects ). 
This way, the function `is_valid_hmac_notification` won't affect the original `dict_object` due to the use of `copy.deepcopy()` creating a independent copy of the object

**Tested scenarios**
add unit test

**Fixed issue**:  <!-- #-prefixed issue number -->
fixes: #278 