### PR TITLE
Add functionality to update headers from kwargs and adjust README acc…

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -345,6 +345,12 @@ class AdyenClient(object):
         if idempotency_key:
             headers[self.IDEMPOTENCY_HEADER_NAME] = idempotency_key
 
+        # Additional headers provided via the `header_parameters` keyword argument
+        # Pass as a keyword argument in the method call.
+        if 'header_parameters' in kwargs:
+            headers.update(kwargs['header_parameters'])
+            kwargs.pop('header_parameters')
+
         url = self._determine_api_url(platform, endpoint)
 
         if 'query_parameters' in kwargs:

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ adyen.management.account_company_level_api.get_companies(query_parameters=query_
 
 Define a dictionary named containing the headers you want to include in your request.
 
-~~~~ pyhton    
+~~~~ python    
     header_parameters = {
         "Var1": "Var2",
         "Var2": "Var1"
@@ -163,7 +163,7 @@ Define a dictionary named containing the headers you want to include in your req
 
 Pass the dictionary as an additional argument to the method where you make the API call.
 
-~~~~ pyhton  
+~~~~ python  
     adyen.checkout.payments_api.payments(header_parameters=headers)
 ~~~~
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ pass the dictionary to the method as an additional argument.
 adyen.management.account_company_level_api.get_companies(query_parameters=query_parameters)
 ~~~~
 
+### Using Header Parameters
+
+Define a dictionary named containing the headers you want to include in your request.
+
+~~~~ pyhton    
+    header_parameters = {
+        "Var1": "Var2",
+        "Var2": "Var1"
+    }
+~~~~
+
+Pass the dictionary as an additional argument to the method where you make the API call.
+
+~~~~ pyhton  
+    adyen.checkout.payments_api.payments(header_parameters=headers)
+~~~~
+
 ### Handling exceptions
 
 Adyen service exceptions extend the AdyenError class. After you catch this exception, you can access the 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ adyen.management.account_company_level_api.get_companies(query_parameters=query_
 
 ### Using Header Parameters
 
-Define a dictionary named containing the headers you want to include in your request.
+Define a dictionary containing the headers you want to include in your request.
 
 ~~~~ python    
     header_parameters = {

--- a/test/ClientTest.py
+++ b/test/ClientTest.py
@@ -13,6 +13,6 @@ class TestClient(unittest.TestCase):
 
     client = adyen.client
     test = BaseTest(adyen)
-    client.xapikey = "YourXapikey"
+    client.xapikey = "YOUR_API_KEY"
     client.platform = "test"
     lib_version = settings.LIB_VERSION

--- a/test/UtilTest.py
+++ b/test/UtilTest.py
@@ -7,6 +7,7 @@ from Adyen.util import (
     is_valid_hmac_notification,
     get_query
 )
+
 try:
     from BaseTest import BaseTest
 except ImportError:
@@ -65,14 +66,13 @@ class UtilTest(unittest.TestCase):
             mixed_notification = load(file)
             self.assertTrue(is_valid_hmac_notification(mixed_notification, hmac_key))
 
-
     def test_query_string_creation(self):
         query_parameters = {
-            "pageSize":7,
-            "pageNumber":3
+            "pageSize": 7,
+            "pageNumber": 3
         }
         query_string = get_query(query_parameters)
-        self.assertEqual(query_string,'?pageSize=7&pageNumber=3')
+        self.assertEqual(query_string, '?pageSize=7&pageNumber=3')
 
     def test_passing_xapikey_in_method(self):
         request = {'merchantAccount': "YourMerchantAccount"}
@@ -96,10 +96,10 @@ class UtilTest(unittest.TestCase):
         self.test = BaseTest(self.adyen)
         self.client.platform = "test"
         self.adyen.client = self.test.create_client_from_file(200, request,
-                                                            "test/mocks/"
-                                                            "checkout/"
-                                                            "paymentmethods"
-                                                            "-success.json")
+                                                              "test/mocks/"
+                                                              "checkout/"
+                                                              "paymentmethods"
+                                                              "-success.json")
         result = self.adyen.checkout.payments_api.payment_methods(request, xapikey="YourXapikey")
         self.adyen.client.http_client.request.assert_called_once_with(
             'POST',
@@ -111,25 +111,24 @@ class UtilTest(unittest.TestCase):
 
     def test_is_valid_hmac_notification_removes_additional_data(self):
         notification = {
-                            "live":"false",
-                            "notificationItems":[
-                                {
-                                    "NotificationRequestItem":{
-                                        "additionalData":{
-                                        "hmacSignature":"11aa",
-                                        "fraudResultType":"GREEN",
-                                        "fraudManualReview": "false",
-                                        "totalFraudScore":"75"
-                                        },
-                                        "amount":{
-                                        "currency":"USD",
-                                        "value":10000
-                                        },
-                                        "success":"true"
-                                        
-                                    }
-                                }
-                            ]}
+            "live": "false",
+            "notificationItems": [
+                {
+                    "NotificationRequestItem": {
+                        "additionalData": {
+                            "hmacSignature": "11aa",
+                            "fraudResultType": "GREEN",
+                            "fraudManualReview": "false",
+                            "totalFraudScore": "75"
+                        },
+                        "amount": {
+                            "currency": "USD",
+                            "value": 10000
+                        },
+                        "success": "true"
+
+                    }
+                }
+            ]}
         is_valid_hmac_notification(notification, "11aa")
         self.assertIsNotNone(notification['notificationItems'][0]['NotificationRequestItem']['additionalData'])
-    


### PR DESCRIPTION
Add functionality to update headers from kwargs
Adjust README with new functionality details

This commit adds a new feature to the call_adyen_api method in the Adyen client class. It checks if 'header_parameters' exist in kwargs and updates the headers accordingly. If present, the headers dictionary is updated with the values from 'header_parameters’.

Changes:
- Added conditional check for 'header_parameters' in kwargs
- Updated headers dictionary if 'header_parameters' exist
- Updated README with details about updating headers from kwargs


