### PR TITLE
Hmac validation bank webhooks

### DIFF
--- a/Adyen/util.py
+++ b/Adyen/util.py
@@ -7,7 +7,7 @@ import binascii
 import copy
 
 
-
+# generates HMAC signature for the NotificationRequest object
 def generate_notification_sig(dict_object, hmac_key):
 
     if not isinstance(dict_object, dict):
@@ -36,7 +36,30 @@ def generate_notification_sig(dict_object, hmac_key):
     return base64.b64encode(hm.digest())
 
 
+# generates HMAC signature for the payload (bytes)
+def generate_payload_sig(payload, hmac_key):
+
+    if not isinstance(payload, bytes):
+        raise ValueError("Must Provide payload as bytes")
+
+    hmac_key = binascii.a2b_hex(hmac_key)
+
+    hm = hmac.new(hmac_key, payload, hashlib.sha256)
+    return base64.b64encode(hm.digest())
+
+
 def is_valid_hmac_notification(dict_object, hmac_key):
+    """
+    validates the HMAC signature of the NotificationRequestItem object. Use for webhooks that provide the
+    hmacSignature as part of the payload `AdditionalData` (i.e. Payments)
+    Args:
+        dict_object: object with a list of notificationItems
+        hmac_key: HMAC key to generate the signature
+
+    Returns:
+        boolean: true when HMAC signature is valid
+    """
+
     dict_object = copy.deepcopy(dict_object) 
 
     if 'notificationItems' in dict_object:
@@ -51,6 +74,25 @@ def is_valid_hmac_notification(dict_object, hmac_key):
             merchant_sign = generate_notification_sig(dict_object, hmac_key)
             merchant_sign_str = merchant_sign.decode("utf-8")
             return hmac.compare_digest(merchant_sign_str, expected_sign)
+
+
+def is_valid_hmac_payload(hmac_signature, hmac_key, payload):
+    """
+    validates the HMAC signature of a payload against an expected signature. Use for webhooks that provide the
+    hmacSignature in the HTTP header (i.e. Banking, Management API)
+    Args:
+        hmac_signature: HMAC signature to validate
+        hmac_key: HMAC key to generate the signature
+        payload: webhook payload
+
+    Returns:
+        boolean: true when HMAC signature is valid
+    """
+
+    merchant_sign = generate_payload_sig(payload, hmac_key)
+    merchant_sign_str = merchant_sign.decode("utf-8")
+
+    return hmac.compare_digest(merchant_sign_str, hmac_signature)
 
 
 def get_query(query_parameters):


### PR DESCRIPTION
## Summary
The library provides only support for validating webhook payloads that include the HMAC signature in the request body `AdditionalData` (i.e. standard webhooks).  
This PR adds the method `is_valid_hmac_payload` to validate the webhook payloads that include the HMAC signature in the HTTP header (.i.e banking webhooks).

## Tested scenarios
Added unit testing, tested with the [Adyen Sample app](https://github.com/adyen-examples/adyen-python-online-payments)
