### PR TITLE
added new issues yml

### DIFF
--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -1,0 +1,14 @@
+name: Label New Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add 'needs response' label to new issues
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'needs response'


### PR DESCRIPTION
Added new issues .yml that will automatically add a 'needs response' label to new git issues.
This will make sure issues won't be marked as stale whenever we don't reply in 14 days.