### PR TITLE
fix: Correct possdk live endpoint construction

### DIFF
--- a/Adyen/client.py
+++ b/Adyen/client.py
@@ -145,8 +145,13 @@ class AdyenClient(object):
                 error_string = "Please set your live suffix. You can set it by running " \
                                "adyen.client.live_endpoint_prefix = 'Your live suffix'"
                 raise AdyenEndpointInvalidFormat(error_string)
-            endpoint = endpoint.replace("https://checkout-test.adyen.com/",
-                                        "https://" + self.live_endpoint_prefix + "-checkout-live.adyenpayments.com/checkout/")
+            
+            if "possdk" in endpoint:
+                endpoint = endpoint.replace("https://checkout-test.adyen.com/",
+                                            "https://" + self.live_endpoint_prefix + "-checkout-live.adyenpayments.com/")
+            else:
+                endpoint = endpoint.replace("https://checkout-test.adyen.com/",
+                                            "https://" + self.live_endpoint_prefix + "-checkout-live.adyenpayments.com/checkout/")
 
         endpoint = endpoint.replace("-test", "-live")
 

--- a/test/DetermineEndpointTest.py
+++ b/test/DetermineEndpointTest.py
@@ -1,6 +1,7 @@
 import Adyen
 from Adyen import settings
 import unittest
+from Adyen.services.posMobile import AdyenPosMobileApi
 
 try:
     from BaseTest import BaseTest
@@ -28,6 +29,15 @@ class TestDetermineUrl(unittest.TestCase):
         url = self.adyen.client._determine_api_url("live", self.checkout_url + "/payments")
         self.assertEqual("https://1797a841fbb37ca7-AdyenDemo-checkout-"
                          f"live.adyenpayments.com/checkout/{self.checkout_version}/payments", url)
+    
+    def test_pos_mobile_api_url_live(self):
+        self.client.live_endpoint_prefix = "1797a841fbb37ca7-AdyenDemo"
+        pos_mobile_api = AdyenPosMobileApi(self.client)
+        pos_mobile_url = pos_mobile_api.baseUrl
+        pos_mobile_version = pos_mobile_url.split('/')[-1]
+        url = self.adyen.client._determine_api_url("live", pos_mobile_url + "/sessions")
+        self.assertEqual("https://1797a841fbb37ca7-AdyenDemo-checkout-"
+                        f"live.adyenpayments.com/checkout/possdk/{pos_mobile_version}/sessions", url)
 
     def test_checkout_api_url(self):
         self.client.live_endpoint_prefix = None


### PR DESCRIPTION
**Description**
The live endpoint for possdk was being constructed incorrectly, with an extra /checkout segment in the URL path. This was causing 'Resource not found' errors when using the AdyenPosMobileApi in the live environment.

This commit fixes the endpoint construction by removing the extra /checkout segment for possdk endpoints. It also adds a unit test to verify the correct behavior.

**Tested scenarios**
See unit tests

**Fixed issue**:
https://github.com/Adyen/adyen-python-api-library/issues/369