### PR TITLE
Add workflow_call trigger to python-ci.yml

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -10,6 +10,7 @@ on:
       - main
       - develop
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
The publish workflow has [failed](https://github.com/Adyen/adyen-python-api-library/actions/runs/16645211259) because it is not able to re-use (invoke) another workflow.
The error has prevented the latest releases (on GitHub) to be published on [pypi](https://pypi.org/project/Adyen/).

This PR updates `.github/workflows/python-ci.yml` to add `workflow_call` (this was dropped by mistake some time ago).

Fix #390 