### PR TITLE
Release workflow: run on merged PRs 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Run on workflow_dispatch OR when PR is merged from same repository
+    if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository) }}    
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Enhanced the conditional check when the action runs. The workflow now only runs when PRs are successfully merged (not just closed) by adding `github.event.pull_request.merged == true` condition.
Running manually (on `workflow_dispatch`) is also preserved.