### PR TITLE
fix: remove unused dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ maintainers = [
     {name = "Adyen", email = "support@adyen.com"},
 ]
 keywords = ["payments", "adyen", "fintech"]
-dependencies = ["pydantic>=2.0"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
The pydantic dependency is unused at the moment, so there is no need to be listed in the `pyproject.toml`. Furthermore, it's missing in `setup.py` (the use of `pyproject.toml` and `setup.py` is out-of-scope for now).