### PR TITLE
Fix unknown properties returning None instead of raising AttributeError

### DIFF
--- a/Adyen/services/base.py
+++ b/Adyen/services/base.py
@@ -14,6 +14,9 @@ class AdyenBase:
         client_attr = ["username", "password", "platform"]
         if attr in client_attr:
             return self.client[attr]
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{attr}'"
+        )
 
 
 class AdyenServiceBase(AdyenBase):

--- a/test/ClientTest.py
+++ b/test/ClientTest.py
@@ -21,5 +21,7 @@ class TestClient(unittest.TestCase):
     def test_unknown_properties_raise_attribute_error(self):
         with self.assertRaises(AttributeError):
             _ = self.adyen.foobar
+        # Resolve parent attributes outside of assertRaises to avoid false positives
+        payments_api = self.adyen.payment.payments_api
         with self.assertRaises(AttributeError):
-            _ = self.adyen.payment.payments_api.foobar
+            _ = payments_api.foobar

--- a/test/ClientTest.py
+++ b/test/ClientTest.py
@@ -17,3 +17,9 @@ class TestClient(unittest.TestCase):
     client.xapikey = "YOUR_API_KEY"
     client.platform = "test"
     lib_version = settings.LIB_VERSION
+
+    def test_unknown_properties_raise_attribute_error(self):
+        with self.assertRaises(AttributeError):
+            _ = self.adyen.foobar
+        with self.assertRaises(AttributeError):
+            _ = self.adyen.payment.payments_api.foobar


### PR DESCRIPTION
This PR fixes a bug (Issue #397) where accessing non-existent attributes on any subclass of AdyenBase (e.g. adyen.foobar) incorrectly returned None instead of raising an AttributeError, which led to confusing runtime errors such as TypeError: 'NoneType' object is not callable.